### PR TITLE
don't fail when DNF can't reach repos during sub-man prereqs

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -284,7 +284,10 @@ def install_prereqs():
         dnf_base.conf.read()
         dnf_base.conf.substitutions.update_from_etc('/')
         dnf_base.read_all_repos()
-        dnf_base.fill_sack()
+        try:
+            dnf_base.fill_sack()
+        except:  # noqa: E722, pylint:disable=bare-except
+            pass
         pkg_list = dnf_base.sack.query().filter(name='subscription-manager')
         subman_installed = pkg_list.installed().run()
         subman_available = pkg_list.available().run()


### PR DESCRIPTION
When a host has repositories configured it can't reach, DNF will error
out when we call `dnf_base.fill_sack()` and abort the execution of the
script.
However, we only need repo data to learn whether sub-man is available,
but given in most cases it's installed already, we don't need this
information and can live with it not being upgradeable (the code later
on handles that case gracefully).
